### PR TITLE
make env extendable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,21 @@
-import {DotenvConfigOptions, config} from 'dotenv';
+import {DotenvConfigOptions, config, DotenvParseOutput} from 'dotenv';
 
 export type PluginTransformResults = {
     code?: string;
     id?: string;
 };
+export type ExtConfigType = {
+    extend: DotenvParseOutput;
+}
 
 // https://stackoverflow.com/a/1144788/9238321
 function replaceAll(str: string, find: string, replace: string) {
     return str.replace(new RegExp(find.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1"), 'g'), replace);
 }
 
-export function env (options?: DotenvConfigOptions) {
-    const { parsed: result } = config(options);
+export function env (options?: DotenvConfigOptions & ExtConfigType) {
+    const { parsed } = config(options);
+    const result = { ...parsed, ...(options?.extend || {}) };
     return {
         name: 'env',
         transform: (


### PR DESCRIPTION
this PR allow you to extend environment parameters taken from `.env`
for i.e. I need to pass generated endpoints to front app:
```typescript
env({
    path: resolve(`./.env.${process.env.NODE_ENV}`),
    extend: {
        KMS_HOST: require('../microservices/kms-service/stack.json').ServiceEndpoint,
        CFG_HOST: require('../microservices/root-service/stack.json').ServiceEndpoint,
        URL_HOST: require('../microservices/shortener-service/stack.json').ServiceEndpoint,
    },
}),
```